### PR TITLE
check whether an object is an instance of datetime.date

### DIFF
--- a/src/super_collections/__init__.py
+++ b/src/super_collections/__init__.py
@@ -30,7 +30,7 @@ class CustomEncoder(json.JSONEncoder):
     Used for debugging purposes.
     """
     def default(self, obj: Any) -> Any:
-        if isinstance(obj, datetime):
+        if isinstance(obj, datetime.date):
             return obj.isoformat()
         if isinstance(obj, UserDict):
             # for objects used by some packages


### PR DESCRIPTION
Since datetime itself is not a type, it previously failed with

    TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union